### PR TITLE
Add database name tab completion for flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,6 @@ Examples:
 	ValidArgsFunction: completionFunc,
 }
 
-
 func init() {
 	rootCmd.Flags().StringVarP(&database, "database", "d", "", "Database name or file")
 	rootCmd.Flags().StringVarP(&host, "host", "h", "", "Database host")
@@ -228,8 +227,8 @@ func completionFunc(cmd *cobra.Command, args []string, toComplete string) ([]str
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	// mutually exclusive flags
-	if mysql && postgres && database != "" {
+	// database flag cannot be combined with database type flags
+	if database != "" && (mysql || postgres) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	postgres = postgres || database == "postgres"
@@ -462,7 +461,6 @@ func completionFunc(cmd *cobra.Command, args []string, toComplete string) ([]str
 	}
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
-
 
 // Sentry DSN (hard-coded)
 const SentryDSN = "https://685bea62d5921e602f7adcad1aae6201@o30558.ingest.us.sentry.io/4510273814855680"


### PR DESCRIPTION
- Add support for both --pg/--postgres and --my/--mysql flags in completion
- Use --host, --port, --username, and --password flags for database connections
- Default to localhost and standard ports (5432 for PostgreSQL, 3306 for MySQL)
- Apply connection parameters to both database and table name completion
- Fix MySQL table query to use proper placeholder syntax (? instead of $1)

This enables tab completion like:
- ted --pg <TAB> - lists databases on localhost
- ted --pg --host myhost --port 5433 <TAB> - lists databases on myhost:5433
- ted --my --username myuser --password pass <TAB> - lists databases with credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves tab completion to list databases/tables for PostgreSQL/MySQL using --pg/--postgres and --my/--mysql, honoring host/port/username/password with defaults and fixing MySQL query placeholders.
> 
> - **CLI Completion**:
>   - Supports both `--pg`/`--postgres` and `--my`/`--mysql` in `completionFunc`, with mutual exclusivity and disallowing combination with `-d/--database`.
>   - Uses `--host`, `--port`, `--username`, `--password` to build connection strings for completion; defaults to `localhost`, `5432` (PostgreSQL), `3306` (MySQL); falls back to current OS user if `--username` is unset.
>   - Applies connection params to both database listing (no args) and table listing (1 arg) for PostgreSQL and MySQL.
>   - Fixes MySQL table query to use `?` placeholder and constructs DSNs with/without password appropriately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb1eb934ddd92a4ed38647393c081aa7d2444a9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->